### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-css-inline
+css-inline==0.10.1
 markdown-it-py
 mdit-py-plugins
 pathlib2

--- a/src/markdown_utils.py
+++ b/src/markdown_utils.py
@@ -396,7 +396,7 @@ class markdown_processor:
         
         full_html = self.html_body_to_full_html(html_body, for_inline=True)
 
-        inliner = css_inline.CSSInliner(remove_style_tags=True)
+        inliner = css_inline.CSSInliner()
         html_body = inliner.inline(full_html)
 
         r = regex.compile(r'(<html>.*?<body[^>]*>|</body>.*?</html>)', regex.DOTALL)

--- a/src/normalize_clipboard.py
+++ b/src/normalize_clipboard.py
@@ -24,7 +24,7 @@ def markdownify_convert(html):
     from markdownify import MarkdownConverter
     from bs4 import BeautifulSoup
 
-    inliner = css_inline.CSSInliner(remove_style_tags=True)
+    inliner = css_inline.CSSInliner()
     html = inliner.inline(html)
 
     soup = BeautifulSoup(html, "html.parser")

--- a/src/note_processor.py
+++ b/src/note_processor.py
@@ -657,7 +657,7 @@ class NotesWriter:
             joined_markdown_text = None
 
         if full_html:
-            inliner = css_inline.CSSInliner(remove_style_tags=True)
+            inliner = css_inline.CSSInliner()
             inlined_html = inliner.inline(full_html)
         else:
             inlined_html = None

--- a/test/normalizer_test.md
+++ b/test/normalizer_test.md
@@ -21,7 +21,7 @@ Psychology's great strength is that it uses scientific observation to systematic
 ### markdown 会被保留
 
 ```python
-        inliner = css_inline.CSSInliner(remove_style_tags=True)
+        inliner = css_inline.CSSInliner()
         inlined_html = inliner.inline(full_html)
         PutHtml(inlined_html, joined_markdown_text)
 ```

--- a/test/normalizer_test.txt
+++ b/test/normalizer_test.txt
@@ -39,7 +39,7 @@ psychology is
 ### markdown会被保留
 
 ```python
-        inliner = css_inline.CSSInliner(remove_style_tags=True)
+        inliner = css_inline.CSSInliner()
         inlined_html = inliner.inline(full_html)
         PutHtml(inlined_html, joined_markdown_text)
 ```


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version.
Also it pins it in the `requirements.txt` file and updates the inlining configuration. In the latest version, it removes `style` tags by default + I removed the `remove_style_tags` config option from the library (now it has `keep_style_tags` instead)